### PR TITLE
Add section on var declarations

### DIFF
--- a/chunked/chap3.html
+++ b/chunked/chap3.html
@@ -2838,6 +2838,47 @@ changes. If you have used <code>POPULATION</code> throughout your program instea
 of a literal, you only have to change its value once.</p>
 </div>
 </div>
+<div class="sect3">
+<h4 id="_var_declarations">3.3.6. Var Declarations</h4>
+<div class="paragraph">
+<p>This section describes a change to the Java language that was introduced in Java 10.  Consider the following variable declarations that include an initial value assignment:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="java"><span class="kt">int</span> <span class="n">x</span> <span class="o">=</span> <span class="mi">10</span><span class="o">;</span>
+<span class="nc">String</span> <span class="n">message</span> <span class="o">=</span> <span class="s">"Hello there."</span>
+<span class="nc">Wombat</span> <span class="n">w</span> <span class="o">=</span> <span class="k">new</span> <span class="nc">Wombat</span><span class="o">();</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Each of the type names in the declaration (<code>int</code>, <code>String</code>, and <code>Wombat</code>) is obvious based on the type of the initial value.  Variable <code>x</code> is obviously an <code>int</code>, variable <code>message</code> is obviously a <code>String</code>, and variable <code>w</code> is obviously a <code>Wombat</code>.</p>
+</div>
+<div class="paragraph">
+<p>Starting in Java 10, the compiler can infer the type of the variable from the type of the initial value, obviating the need for a type declaration.  This feature is called <em>local variable type inference</em>.  The type declaration can be replaced by the "reserved type name" <code>var</code> and the compiler will do the inferencing:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="java"><span class="kt">var</span> <span class="n">x</span> <span class="o">=</span> <span class="mi">10</span><span class="o">;</span>
+<span class="kt">var</span> <span class="n">message</span> <span class="o">=</span> <span class="s">"Hello there."</span>
+<span class="kt">var</span> <span class="n">w</span> <span class="o">=</span> <span class="k">new</span> <span class="nc">Wombat</span><span class="o">();</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Use of <code>var</code> can result in clearer and more concise code, as long as the type being inferred by the compiler is obvious and what you intended. For example, if you intended <code>x</code> to be a <code>double</code>, you would need to use a declaration like one of these:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="java"><span class="c1">// Use a literal double as the initial value...</span>
+<span class="kt">var</span> <span class="n">x</span> <span class="o">=</span> <span class="mf">10.0</span><span class="o">;</span>
+
+<span class="c1">// Or, explicitly declare the type...</span>
+<span class="kt">double</span> <span class="n">x</span> <span class="o">=</span> <span class="mi">10</span><span class="o">;</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Note that this feature is called <em>local variable type inference</em>.  The compiler only does type inferencing on <em>local variables</em>, not on fields, method parameters, or return types.</p>
+</div>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_syntax_useful_libraries">3.4. Syntax: Useful libraries</h3>

--- a/full/chapters/strings-primitive-types/programs/VarDemo.java
+++ b/full/chapters/strings-primitive-types/programs/VarDemo.java
@@ -1,0 +1,7 @@
+public class VarDemo {
+    public static void main(String[] args) {
+        double x = 10;
+        x = x + 0.5;
+        System.out.println("x = " + x);
+    }
+}

--- a/full/index.html
+++ b/full/index.html
@@ -8891,6 +8891,47 @@ changes. If you have used <code>POPULATION</code> throughout your program instea
 of a literal, you only have to change its value once.</p>
 </div>
 </div>
+<div class="sect3">
+<h4 id="_var_declarations">3.3.6. Var Declarations</h4>
+<div class="paragraph">
+<p>This section describes a change to the Java language that was introduced in Java 10.  Consider the following variable declarations that include an initial value assignment:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="java"><span class="kt">int</span> <span class="n">x</span> <span class="o">=</span> <span class="mi">10</span><span class="o">;</span>
+<span class="nc">String</span> <span class="n">message</span> <span class="o">=</span> <span class="s">"Hello there."</span>
+<span class="nc">Wombat</span> <span class="n">w</span> <span class="o">=</span> <span class="k">new</span> <span class="nc">Wombat</span><span class="o">();</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Each of the type names in the declaration (<code>int</code>, <code>String</code>, and <code>Wombat</code>) is obvious based on the type of the initial value.  Variable <code>x</code> is obviously an <code>int</code>, variable <code>message</code> is obviously a <code>String</code>, and variable <code>w</code> is obviously a <code>Wombat</code>.</p>
+</div>
+<div class="paragraph">
+<p>Starting in Java 10, the compiler can infer the type of the variable from the type of the initial value, obviating the need for a type declaration.  This feature is called <em>local variable type inference</em>.  The type declaration can be replaced by the "reserved type name" <code>var</code> and the compiler will do the inferencing:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="java"><span class="kt">var</span> <span class="n">x</span> <span class="o">=</span> <span class="mi">10</span><span class="o">;</span>
+<span class="kt">var</span> <span class="n">message</span> <span class="o">=</span> <span class="s">"Hello there."</span>
+<span class="kt">var</span> <span class="n">w</span> <span class="o">=</span> <span class="k">new</span> <span class="nc">Wombat</span><span class="o">();</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Use of <code>var</code> can result in clearer and more concise code, as long as the type being inferred by the compiler is obvious and what you intended. For example, if you intended <code>x</code> to be a <code>double</code>, you would need to use a declaration like one of these:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="java"><span class="c1">// Use a literal double as the initial value...</span>
+<span class="kt">var</span> <span class="n">x</span> <span class="o">=</span> <span class="mf">10.0</span><span class="o">;</span>
+
+<span class="c1">// Or, explicitly declare the type...</span>
+<span class="kt">double</span> <span class="n">x</span> <span class="o">=</span> <span class="mi">10</span><span class="o">;</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Note that this feature is called <em>local variable type inference</em>.  The compiler only does type inferencing on <em>local variables</em>, not on fields, method parameters, or return types.</p>
+</div>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_syntax_useful_libraries">3.4. Syntax: Useful libraries</h3>

--- a/full/strings-primitive-types.adoc
+++ b/full/strings-primitive-types.adoc
@@ -1996,6 +1996,41 @@ different places in your program, changing it to `30000` requires five
 changes. If you have used `POPULATION` throughout your program instead
 of a literal, you only have to change its value once.
 
+==== Var Declarations
+
+This section describes a change to the Java language that was introduced in Java 10.  Consider the following variable declarations that include an initial value assignment:
+
+[source, java]
+----
+int x = 10;
+String message = "Hello there."
+Wombat w = new Wombat();
+----
+
+Each of the type names in the declaration (`int`, `String`, and `Wombat`) is obvious based on the type of the initial value.  Variable `x` is obviously an `int`, variable `message` is obviously a `String`, and variable `w` is obviously a `Wombat`.
+
+Starting in Java 10, the compiler can infer the type of the variable from the type of the initial value, obviating the need for a type declaration.  This feature is called _local variable type inference_.  The type declaration can be replaced by the "reserved type name" `var` and the compiler will do the inferencing:
+
+[source, java]
+----
+var x = 10;
+var message = "Hello there."
+var w = new Wombat();
+----
+
+Use of `var` can result in clearer and more concise code, as long as the type being inferred by the compiler is obvious and what you intended. For example, if you intended `x` to be a `double`, you would need to use a declaration like one of these:
+
+[source, java]
+----
+// Use a literal double as the initial value...
+var x = 10.0;
+
+// Or, explicitly declare the type...
+double x = 10;  
+----
+
+Note that this feature is called _local variable type inference_.  The compiler only does type inferencing on _local variables_, not on fields, method parameters, or return types.
+
 === Syntax: Useful libraries
 
 Computer software is difficult to write, but many of the same problems

--- a/index.adoc
+++ b/index.adoc
@@ -21,22 +21,18 @@ __Attacking Problems with Java__ is an introduction to programming using the Jav
 This website is being updated during the summer of 2024, with changes to be completed by mid-August.
 ====
 
-=== Planned Changes
+=== Changes Planned and Completed
 
-1. Add keyword `var`.
-2. Describe enhancements to `switch` statements.
-3. Describe improvements to the `interface` specification, including `static` methods and `default` methods.
-4. Explain the `instanceof` binding variable.
-5. Introduce type inference for type variables.
-6. Explain the `try`-with-resources feature.
-7. Replace the `File` type with `Path`.
-8. Include an explanation of the `enum` type.
-9. Include a chapter on lambdas, closures, and functional expressions.
-10. Include a chapter on streams (or add to an existing chapter). 
-
-=== Completed Changes
-
-_None yet!_
+* [x] Add section on `var` declarations (Section 3.3.6).
+* [ ] Describe enhancements to `switch` statements.
+* [ ] Describe improvements to the `interface` specification, including `static` methods and `default` methods.
+* [ ] Explain the `instanceof` binding variable.
+* [ ] Introduce type inference for type variables.
+* [ ] Explain the `try`-with-resources feature.
+* [ ] Replace the `File` type with `Path`.
+* [ ] Include an explanation of the `enum` type.
+* [ ] Include a chapter on lambdas, closures, and functional expressions.
+* [ ] Include a chapter on streams (or add to an existing chapter). 
 
 == Availability
 

--- a/index.html
+++ b/index.html
@@ -475,46 +475,40 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </table>
 </div>
 <div class="sect2">
-<h3 id="_planned_changes">Planned Changes</h3>
-<div class="olist arabic">
-<ol class="arabic">
+<h3 id="_changes_planned_and_completed">Changes Planned and Completed</h3>
+<div class="ulist checklist">
+<ul class="checklist">
 <li>
-<p>Add keyword <code>var</code>.</p>
+<p><i class="fa fa-check-square-o"></i> Add section on <code>var</code> declarations (Section 3.3.6).</p>
 </li>
 <li>
-<p>Describe enhancements to <code>switch</code> statements.</p>
+<p><i class="fa fa-square-o"></i> Describe enhancements to <code>switch</code> statements.</p>
 </li>
 <li>
-<p>Describe improvements to the <code>interface</code> specification, including <code>static</code> methods and <code>default</code> methods.</p>
+<p><i class="fa fa-square-o"></i> Describe improvements to the <code>interface</code> specification, including <code>static</code> methods and <code>default</code> methods.</p>
 </li>
 <li>
-<p>Explain the <code>instanceof</code> binding variable.</p>
+<p><i class="fa fa-square-o"></i> Explain the <code>instanceof</code> binding variable.</p>
 </li>
 <li>
-<p>Introduce type inference for type variables.</p>
+<p><i class="fa fa-square-o"></i> Introduce type inference for type variables.</p>
 </li>
 <li>
-<p>Explain the <code>try</code>-with-resources feature.</p>
+<p><i class="fa fa-square-o"></i> Explain the <code>try</code>-with-resources feature.</p>
 </li>
 <li>
-<p>Replace the <code>File</code> type with <code>Path</code>.</p>
+<p><i class="fa fa-square-o"></i> Replace the <code>File</code> type with <code>Path</code>.</p>
 </li>
 <li>
-<p>Include an explanation of the <code>enum</code> type.</p>
+<p><i class="fa fa-square-o"></i> Include an explanation of the <code>enum</code> type.</p>
 </li>
 <li>
-<p>Include a chapter on lambdas, closures, and functional expressions.</p>
+<p><i class="fa fa-square-o"></i> Include a chapter on lambdas, closures, and functional expressions.</p>
 </li>
 <li>
-<p>Include a chapter on streams (or add to an existing chapter).</p>
+<p><i class="fa fa-square-o"></i> Include a chapter on streams (or add to an existing chapter).</p>
 </li>
-</ol>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_completed_changes">Completed Changes</h3>
-<div class="paragraph">
-<p><em>None yet!</em></p>
+</ul>
 </div>
 </div>
 </div>
@@ -825,7 +819,7 @@ eventually move onto Chapter 15 for more depth in GUIs and Swing. Instructors wh
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-06-24 17:35:04 -0400
+Last updated 2024-07-02 19:35:48 -0400
 </div>
 </div>
 <script type="text/x-mathjax-config">


### PR DESCRIPTION
First actual book update.  I have updated the checklist in the overview (index.adoc).  Not sure I'm happy with the style, but there it is for now.  One glitch is that I don't think we can use links to refer to chapters or sections by name from the overview.  Also not sure how to or if we should reference Java versions as we introduce new material.  For example, the var declarations were added in Java 10, which I note in the new section (for now).